### PR TITLE
Added underline to links in faktaboxes (OTRS-35656).

### DIFF
--- a/less/kb/fact-box.less
+++ b/less/kb/fact-box.less
@@ -18,6 +18,9 @@
   p{
     font:@fact-box-p-xs;
   }
+  a{
+      text-decoration:underline;
+  }
 }
 .col-md-6, .col-sm-6, .col-md-12, .col-sm-12{
   .factBox{


### PR DESCRIPTION
@tja1607 

Added underline on all links in faktaboxes. Notice that I haven't tested it at all, since cmsstage apparently has run out of disk space (I have filed an OTRS issue).

As the system is now, there are no underline on links in faktaboxes - that's not on purpose is it?
We have got an OTRS issue on it.